### PR TITLE
added modal ui-component

### DIFF
--- a/publish/resources/js/components/Ui/Modal.vue
+++ b/publish/resources/js/components/Ui/Modal.vue
@@ -106,7 +106,11 @@ import {
 } from '@headlessui/vue';
 
 export default {
-    emits: ['close'],
+    emits: {
+        close(payload: boolean) {
+            return payload;
+        },
+    },
     components: {
         TransitionRoot,
         TransitionChild,
@@ -129,7 +133,7 @@ export default {
         },
     },
 
-    setup({}, { emit }) {
+    setup({}, { emit }: { emit: any }) {
         function close(val: Boolean) {
             emit('close', val);
             emit('update:open', val);

--- a/publish/resources/js/components/Ui/Modal.vue
+++ b/publish/resources/js/components/Ui/Modal.vue
@@ -1,0 +1,143 @@
+<template>
+    <TransitionRoot appear :show="open" as="template">
+        <Dialog as="div" @close="close">
+            <div class="fixed inset-0 z-10 overflow-y-auto">
+                <div class="min-h-screen px-4 text-center">
+                    <TransitionChild
+                        as="template"
+                        enter="duration-300 ease-out"
+                        enter-from="opacity-0"
+                        enter-to="opacity-100"
+                        leave="duration-200 ease-in"
+                        leave-from="opacity-100"
+                        leave-to="opacity-0"
+                    >
+                        <DialogOverlay
+                            class="
+                                fixed
+                                inset-0
+                                filter
+                                bg-black bg-opacity-30
+                                backdrop-filter backdrop-blur-sm
+                            "
+                        />
+                    </TransitionChild>
+
+                    <span
+                        class="inline-block h-screen align-middle"
+                        aria-hidden="true"
+                    >
+                        &#8203;
+                    </span>
+
+                    <TransitionChild
+                        as="template"
+                        enter="duration-300 ease-out"
+                        enter-from="opacity-0 scale-95"
+                        enter-to="opacity-100 scale-100"
+                        leave="duration-200 ease-in"
+                        leave-from="opacity-100 scale-100"
+                        leave-to="opacity-0 scale-95"
+                    >
+                        <div
+                            class="
+                                inline-block
+                                w-full
+                                md:max-w-xl
+                                lg:max-w-3xl
+                                p-6
+                                my-8
+                                relative
+                                overflow-hidden
+                                text-left
+                                align-middle
+                                transition-all
+                                transform
+                                bg-white
+                                shadow-xl
+                                rounded-sm
+                            "
+                        >
+                            <DialogTitle
+                                as="h3"
+                                class="
+                                    text-xl
+                                    font-semibold
+                                    leading-8
+                                    text-gray-900
+                                "
+                            >
+                                {{ title }}
+                            </DialogTitle>
+
+                            <slot />
+
+                            <div class="absolute top-5 right-6">
+                                <button @click="close(false)">
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="-6 -6 24 24"
+                                        width="24"
+                                        height="24"
+                                        preserveAspectRatio="xMinYMin"
+                                        class="icon__icon fill-current"
+                                    >
+                                        <path
+                                            d="M7.314 5.9l3.535-3.536A1 1 0 1 0 9.435.95L5.899 4.485 2.364.95A1 1 0 1 0 .95 2.364l3.535 3.535L.95 9.435a1 1 0 1 0 1.414 1.414l3.535-3.535 3.536 3.535a1 1 0 1 0 1.414-1.414L7.314 5.899z"
+                                        ></path>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div>
+                    </TransitionChild>
+                </div>
+            </div>
+        </Dialog>
+    </TransitionRoot>
+</template>
+
+<script lang="ts">
+import {
+    TransitionRoot,
+    TransitionChild,
+    Dialog,
+    DialogOverlay,
+    DialogTitle,
+} from '@headlessui/vue';
+
+export default {
+    emits: ['close'],
+    components: {
+        TransitionRoot,
+        TransitionChild,
+        Dialog,
+        DialogOverlay,
+        DialogTitle,
+    },
+    props: {
+        title: {
+            type: String,
+            required: true,
+        },
+        button: {
+            type: String,
+            default: 'Öffne Modal',
+        },
+        open: {
+            type: Boolean,
+            default: false,
+        },
+    },
+
+    setup({}, { emit }) {
+        function close(val: Boolean) {
+            emit('close', val);
+            emit('update:open', val);
+        }
+
+        return {
+            close,
+        };
+    },
+};
+</script>

--- a/publish/resources/js/components/Ui/Modal.vue
+++ b/publish/resources/js/components/Ui/Modal.vue
@@ -67,7 +67,7 @@
                                     text-gray-900
                                 "
                             >
-                                {{ title }}
+                                <slot name="title" />
                             </DialogTitle>
 
                             <slot />

--- a/publish/resources/js/components/index.ts
+++ b/publish/resources/js/components/index.ts
@@ -1,6 +1,7 @@
 import Accordion from './Ui/Accordion.vue';
 import Image from './Ui/Image.vue';
 import Button from './Ui/Button.vue';
+import Modal from './Ui/Modal.vue';
 import Head from './App/Head.vue';
 
 const plugin = {
@@ -11,6 +12,7 @@ const plugin = {
         app.component('UiAccordion', Accordion);
         app.component('UiImage', Image);
         app.component('UiButton', Button);
+        app.component('UiModal', Modal);
         /**
          * App-Components
          */


### PR DESCRIPTION
I built a ui-component for a modal which is easily customizable to your own needs and makes it easy to use a modal from a parent component. Headless UI is used under the hood.

This is how you would use the modal inside a template:
```vue
<UiButton @click="isOpen = !isOpen">Modal öffnen</UiButton>
<UiModal v-model:open="isOpen">
     <template v-slot:title> Modal Titel </template>
     <div class="my-2">Hier könnte ihre Werbung stehen</div>
</UiModal>

<script lang="ts">
import { defineComponent, ref } from 'vue';
export default defineComponent({
    setup() {
        const isOpen = ref(false);
        return {
            isOpen,
        };
    },
});
</script>
```